### PR TITLE
feat: keyboard shortcut indicator for search

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,91 +1,117 @@
 <header class="bg-background text-white p-6 sm:p-10" id="banner">
-    {% if page.layout != 'post' %}
-    <div class="flex flex-col items-center">
-        {% if page.title %}
-        <span class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300">
-            {{ page.title }}
-        </span>
-        {% else %}
-        <span class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300">
-            {{ site.title }}
-        </span>
-        {% endif %}
-        {% if page.excerpt != blank %}
-        <p class="mt-2">
-            {{ page.excerpt }}
-        </p>
-        {% else %}
-        <p class="mt-2">
-            An
-            <a class="font-black text-lg bg-gradient-to-r from-sky-300 to-blue-500 text-transparent bg-clip-text after:bg-blue-400"
-                href="https://github.com/{{ site.github_username }}" target="_blank" rel="nofollow noopener noreferrer">open-source
-            </a> developer publication.
-        </p>
-        {% endif %}
-        {% assign searchBoxWhitelist = "/index.html,/404,/topics" | split:","%}
-        {% if searchBoxWhitelist contains page.url %}
-        <button
-            class="flex items-center w-full sm:w-1/2 xl:w-1/3 mt-12 text-left space-x-3 px-4 h-12 bg-white hover:bg-slate-200 shadow-sm rounded-lg text-gray-500"
-            onclick="showSearch()">
-            <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-                stroke-linejoin="round">
-                <path d="m19 19-3.5-3.5"></path>
-                <circle cx="11" cy="11" r="6"></circle>
-            </svg>
-            <span class="flex-auto">Search for posts...</span>
-        </button>
-        {% endif %}
-    </div>
+  {% if page.layout != 'post' %}
+  <div class="flex flex-col items-center">
+    {% if page.title %}
+    <span
+      class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300"
+    >
+      {{ page.title }}
+    </span>
     {% else %}
-    {% assign author = site.data.contributors[page.author]%}
-    <div class="flex flex-col lg:flex-row p-2">
-        <div class="flex justify-center items-center lg:w-1/2 md:mb-0">
-            {% if page.image %}
-            <img src="{{ page.image }}" class="w-full md:w-3/4 lg:w-full rounded-xl shadow-xl aspect-video m-8" />
-            {% endif %}
-        </div>
-        <div class="flex flex-col justify-center lg:items-start w-full lg:w-1/2 lg:ml-12">
-            {% if page.title %}
-            <h1 class="text-4xl font-black tracking-tight">{{ page.title }}</h1>
-            {% endif %}
-            {% if page.excerpt %}
-            <span class="mt-0.5 text-justify">{{ page.excerpt }}</span>
-            {% endif %}
-            {% if page.author %}
-            <div class="flex items-center mt-8">
-                <img class="rounded-full w-14 h-14" src="{{ author.avatar }}" />
-                <div class="ml-4 leading-3">
-                    <a class="font-extrabold text-xl" href="/contributor/{{ page.author | downcase }}">
-                        {{ author.name }}
-                    </a><br />
-                    <span class="text-sm">
-                        Posted on {{ page.date | date:"%B %e, %Y" }}
-                    </span>
-                </div>
-            </div>
-            {% endif %}
-            {% if page.category %}
-            <div class="mt-8">
-                <span>Category: </span>
-                {% for category in page.categories %}
-                <a class="text-sm ml-2 hover:scale-110 category-name !bg-{{ category }} underline-none"
-                    href="/category/{{ category }}">#{{ category }}</a>
-                {% endfor %}
-            </div>
-            {% endif %}
-            {% assign tagSize = page.tags | size %}
-            {% if tagSize != 0 %}
-            <div class="mt-4 sm:mt-1">
-                <span>Tags: </span>
-                {% for tag in page.tags %}
-                {% assign tagName = tag | slugify %}
-                <a class="text-sm ml-2 my-0.5 hover:scale-110 tag-name !bg-{{ tagName }} underline-none"
-                    href="/tag/{{ tagName }}">#{{
-                    tagName }}</a>
-                {% endfor %}
-            </div>
-            {% endif %}
-        </div>
-    </div>
+    <span
+      class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300"
+    >
+      {{ site.title }}
+    </span>
+    {% endif %} {% if page.excerpt != blank %}
+    <p class="mt-2">{{ page.excerpt }}</p>
+    {% else %}
+    <p class="mt-2">
+      An
+      <a
+        class="font-black text-lg bg-gradient-to-r from-sky-300 to-blue-500 text-transparent bg-clip-text after:bg-blue-400"
+        href="https://github.com/{{ site.github_username }}"
+        target="_blank"
+        rel="nofollow noopener noreferrer"
+        >open-source
+      </a>
+      developer publication.
+    </p>
+    {% endif %} {% assign searchBoxWhitelist = "/index.html,/404,/topics" |
+    split:","%} {% if searchBoxWhitelist contains page.url %}
+    <button
+      class="flex items-center w-full sm:w-1/2 xl:w-1/3 mt-12 text-left space-x-3 px-4 h-12 bg-white hover:bg-slate-200 shadow-sm rounded-lg text-gray-500"
+      onclick="showSearch()"
+    >
+      <svg
+        width="24"
+        height="24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="m19 19-3.5-3.5"></path>
+        <circle cx="11" cy="11" r="6"></circle>
+      </svg>
+      <span class="flex-auto">Search for posts...</span>
+
+      <!-- display ctrl+k shortcut for search -->
+      <span
+        class="text-sm text-gray-500 dark:text-gray-200 text-right bg-gray-200 dark:bg-slate-500 rounded-md shadow-md"
+      >
+        <kbd class="pt-1 pl-1 pr-1 pb-1">ctrl+k</kbd>
+      </span>
+    </button>
     {% endif %}
+  </div>
+  {% else %} {% assign author = site.data.contributors[page.author]%}
+  <div class="flex flex-col lg:flex-row p-2">
+    <div class="flex justify-center items-center lg:w-1/2 md:mb-0">
+      {% if page.image %}
+      <img
+        src="{{ page.image }}"
+        class="w-full md:w-3/4 lg:w-full rounded-xl shadow-xl aspect-video m-8"
+      />
+      {% endif %}
+    </div>
+    <div
+      class="flex flex-col justify-center lg:items-start w-full lg:w-1/2 lg:ml-12"
+    >
+      {% if page.title %}
+      <h1 class="text-4xl font-black tracking-tight">{{ page.title }}</h1>
+      {% endif %} {% if page.excerpt %}
+      <span class="mt-0.5 text-justify">{{ page.excerpt }}</span>
+      {% endif %} {% if page.author %}
+      <div class="flex items-center mt-8">
+        <img class="rounded-full w-14 h-14" src="{{ author.avatar }}" />
+        <div class="ml-4 leading-3">
+          <a
+            class="font-extrabold text-xl"
+            href="/contributor/{{ page.author | downcase }}"
+          >
+            {{ author.name }} </a
+          ><br />
+          <span class="text-sm">
+            Posted on {{ page.date | date:"%B %e, %Y" }}
+          </span>
+        </div>
+      </div>
+      {% endif %} {% if page.category %}
+      <div class="mt-8">
+        <span>Category: </span>
+        {% for category in page.categories %}
+        <a
+          class="text-sm ml-2 hover:scale-110 category-name !bg-{{ category }} underline-none"
+          href="/category/{{ category }}"
+          >#{{ category }}</a
+        >
+        {% endfor %}
+      </div>
+      {% endif %} {% assign tagSize = page.tags | size %} {% if tagSize != 0 %}
+      <div class="mt-4 sm:mt-1">
+        <span>Tags: </span>
+        {% for tag in page.tags %} {% assign tagName = tag | slugify %}
+        <a
+          class="text-sm ml-2 my-0.5 hover:scale-110 tag-name !bg-{{ tagName }} underline-none"
+          href="/tag/{{ tagName }}"
+          >#{{ tagName }}</a
+        >
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
 </header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,20 +2,19 @@
   {% if page.layout != 'post' %}
   <div class="flex flex-col items-center">
     {% if page.title %}
-    <span
-      class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300"
-    >
+    <span class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300">
       {{ page.title }}
     </span>
     {% else %}
-    <span
-      class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300"
-    >
+    <span class="font-black text-4xl sm:text-5xl text-white group-hover:text-slate-300">
       {{ site.title }}
     </span>
-    {% endif %} {% if page.excerpt != blank %}
+    {% endif %}
+
+    {% if page.excerpt != blank %}
     <p class="mt-2">{{ page.excerpt }}</p>
     {% else %}
+    
     <p class="mt-2">
       An
       <a
@@ -27,12 +26,14 @@
       </a>
       developer publication.
     </p>
-    {% endif %} {% assign searchBoxWhitelist = "/index.html,/404,/topics" |
-    split:","%} {% if searchBoxWhitelist contains page.url %}
-    <button
-      class="flex items-center w-full sm:w-1/2 xl:w-1/3 mt-12 text-left space-x-3 px-4 h-12 bg-white hover:bg-slate-200 shadow-sm rounded-lg text-gray-500"
-      onclick="showSearch()"
-    >
+
+    {% endif %}
+    {% assign searchBoxWhitelist = "/index.html,/404,/topics" | split:","%}
+    {% if searchBoxWhitelist contains page.url %}
+    
+    <button class="flex items-center w-full sm:w-1/2 xl:w-1/3 mt-12 text-left space-x-3 px-4 h-12 bg-white hover:bg-slate-200 shadow-sm rounded-lg text-gray-500"
+      onclick="showSearch()">
+
       <svg
         width="24"
         height="24"
@@ -45,18 +46,24 @@
         <path d="m19 19-3.5-3.5"></path>
         <circle cx="11" cy="11" r="6"></circle>
       </svg>
+
       <span class="flex-auto">Search for posts...</span>
 
-      <!-- display ctrl+k shortcut for search -->
       <span
-        class="text-sm text-gray-500 dark:text-gray-200 text-right bg-gray-200 dark:bg-slate-500 rounded-md shadow-md"
+        class="hidden lg:block text-sm text-gray-600 text-right tracking-tight"
       >
-        <kbd class="pt-1 pl-1 pr-1 pb-1">ctrl+k</kbd>
+        <kbd class="bg-gray-200 rounded-md shadow-sm py-1 px-2">Ctrl</kbd>
+        +
+        <kbd class="bg-gray-200 rounded-md shadow-sm py-1 px-2">K</kbd>
       </span>
+
     </button>
     {% endif %}
   </div>
-  {% else %} {% assign author = site.data.contributors[page.author]%}
+
+  {% else %}
+  {% assign author = site.data.contributors[page.author]%}
+
   <div class="flex flex-col lg:flex-row p-2">
     <div class="flex justify-center items-center lg:w-1/2 md:mb-0">
       {% if page.image %}
@@ -66,29 +73,32 @@
       />
       {% endif %}
     </div>
-    <div
-      class="flex flex-col justify-center lg:items-start w-full lg:w-1/2 lg:ml-12"
-    >
+    <div class="flex flex-col justify-center lg:items-start w-full lg:w-1/2 lg:ml-12">
       {% if page.title %}
       <h1 class="text-4xl font-black tracking-tight">{{ page.title }}</h1>
-      {% endif %} {% if page.excerpt %}
+      {% endif %}
+      
+      {% if page.excerpt %}
       <span class="mt-0.5 text-justify">{{ page.excerpt }}</span>
-      {% endif %} {% if page.author %}
+      {% endif %}
+
+      {% if page.author %}
       <div class="flex items-center mt-8">
         <img class="rounded-full w-14 h-14" src="{{ author.avatar }}" />
         <div class="ml-4 leading-3">
-          <a
-            class="font-extrabold text-xl"
-            href="/contributor/{{ page.author | downcase }}"
-          >
-            {{ author.name }} </a
-          ><br />
+          <a class="font-extrabold text-xl"
+            href="/contributor/{{ page.author | downcase }}">
+            {{ author.name }}
+          </a>
+          <br />
           <span class="text-sm">
             Posted on {{ page.date | date:"%B %e, %Y" }}
           </span>
         </div>
       </div>
-      {% endif %} {% if page.category %}
+      {% endif %}
+
+      {% if page.category %}
       <div class="mt-8">
         <span>Category: </span>
         {% for category in page.categories %}
@@ -99,10 +109,14 @@
         >
         {% endfor %}
       </div>
-      {% endif %} {% assign tagSize = page.tags | size %} {% if tagSize != 0 %}
+      {% endif %}
+
+      {% assign tagSize = page.tags | size %}
+      {% if tagSize != 0 %}
       <div class="mt-4 sm:mt-1">
         <span>Tags: </span>
-        {% for tag in page.tags %} {% assign tagName = tag | slugify %}
+        {% for tag in page.tags %}
+        {% assign tagName = tag | slugify %}
         <a
           class="text-sm ml-2 my-0.5 hover:scale-110 tag-name !bg-{{ tagName }} underline-none"
           href="/tag/{{ tagName }}"

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -1,16 +1,39 @@
-<div class="hidden fixed top-0 w-full h-full p-6 md:p-14 backdrop-blur-md cursor-pointer z-20" id="search-container">
-    <div class="p-4 bg-white dark:bg-slate-800 mx-auto w-full max-h-full sm:w-3/4 lg:w-1/2 content-center rounded-lg shadow-md shadow-slate-200 dark:shadow-none cursor-auto overflow-auto"
-        id="search-box">
-        <div class="flex items-center">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 stroke-slate-400" fill="none" viewBox="0 0 24 24"
-                stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <input type="text" class="w-full h-full pl-4 text-2xl outline-none dark:bg-slate-800" id="search-input"
-                placeholder="Search..." />
-        </div>
-        <div id="results-container">
-        </div>
+<div
+  class="hidden fixed top-0 w-full h-full p-6 md:p-14 backdrop-blur-md cursor-pointer z-20"
+  id="search-container"
+>
+  <div
+    class="p-4 bg-white dark:bg-slate-800 mx-auto w-full max-h-full sm:w-3/4 lg:w-1/2 content-center rounded-lg shadow-md shadow-slate-200 dark:shadow-none cursor-auto overflow-auto"
+    id="search-box"
+  >
+    <div class="flex items-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-6 w-6 stroke-slate-400"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+      <input
+        type="text"
+        class="w-full h-full pl-4 text-2xl outline-none dark:bg-slate-800"
+        id="search-input"
+        placeholder="Search..."
+      />
+      <!-- display ctrl+k shortcut for search -->
+      <span
+        class="text-sm text-gray-500 dark:text-gray-400 text-right bg-gray-100 rounded-md shadow-md dark:bg-slate-600"
+      >
+        <kbd class="pt-1 pl-1 pr-1 pb-1">esc</kbd>
+      </span>
     </div>
+    <div id="results-container"></div>
+  </div>
 </div>

--- a/_includes/search.html
+++ b/_includes/search.html
@@ -27,11 +27,10 @@
         id="search-input"
         placeholder="Search..."
       />
-      <!-- display ctrl+k shortcut for search -->
       <span
-        class="text-sm text-gray-500 dark:text-gray-400 text-right bg-gray-100 rounded-md shadow-md dark:bg-slate-600"
+        class="hidden lg:block text-sm text-gray-600 text-right tracking-tight ml-2"
       >
-        <kbd class="pt-1 pl-1 pr-1 pb-1">esc</kbd>
+        <kbd class="bg-gray-200 dark:bg-slate-600 dark:text-gray-200 rounded-md shadow-sm py-1 px-2">Esc</kbd>
       </span>
     </div>
     <div id="results-container"></div>


### PR DESCRIPTION
Fixes #13 

- Adds a `ctrl+k` keyboard shortcut indicator in the search bar on the home page. (Adapts to light and dark mode)
- Format code

PFA Screenshots:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/66675022/155890893-873f1fbd-22b2-49ec-8832-0d367a1e623f.png">
<img width="635" alt="image" src="https://user-images.githubusercontent.com/66675022/155890903-99cff79d-7e65-408b-bee0-c128f9fea0f9.png">
<img width="761" alt="image" src="https://user-images.githubusercontent.com/66675022/155890913-9014e272-3db8-4d97-b30c-29cfeb2d7eed.png">
<img width="770" alt="image" src="https://user-images.githubusercontent.com/66675022/155890924-113ca607-72d2-479d-8eb1-ba85c8d5ab64.png">
