### PR TITLE
Fix link underline animation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -18,12 +18,11 @@
     <p class="mt-2">
       An
       <a
-        class="font-black text-lg bg-gradient-to-r from-sky-300 to-blue-500 text-transparent bg-clip-text after:bg-blue-400"
+        class="font-black text-lg text-blue-400 bg-gradient-to-r from-blue-400 to-blue-400"
         href="https://github.com/{{ site.github_username }}"
         target="_blank"
         rel="nofollow noopener noreferrer"
-        >open-source
-      </a>
+        >open-source</a>
       developer publication.
     </p>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -103,7 +103,7 @@
         <span>Category: </span>
         {% for category in page.categories %}
         <a
-          class="text-sm ml-2 hover:scale-110 category-name !bg-{{ category }} underline-none"
+          class="text-sm ml-2 category-name !bg-{{ category }} underline-none"
           href="/category/{{ category }}"
           >#{{ category }}</a
         >
@@ -118,7 +118,7 @@
         {% for tag in page.tags %}
         {% assign tagName = tag | slugify %}
         <a
-          class="text-sm ml-2 my-0.5 hover:scale-110 tag-name !bg-{{ tagName }} underline-none"
+          class="text-sm ml-2 my-0.5 tag-name !bg-{{ tagName }} underline-none"
           href="/tag/{{ tagName }}"
           >#{{ tagName }}</a
         >

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -112,7 +112,7 @@
 
       {% assign tagSize = page.tags | size %}
       {% if tagSize != 0 %}
-      <div class="mt-4 sm:mt-1">
+      <div class="mt-4 sm:mt-3">
         <span>Tags: </span>
         {% for tag in page.tags %}
         {% assign tagName = tag | slugify %}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -76,26 +76,22 @@
         @apply font-bold hover:text-slate-300;
     }
     a {
-        @apply inline-block relative cursor-pointer;
+        @apply relative bg-gradient-to-r from-slate-300 to-slate-300;
+        background-image: linear-gradient(#cbd5e1, #cbd5e1);
+        background-size: 0% 0.125rem;
+        background-repeat: no-repeat;
+        background-position: left bottom;
+        transition: background-size 300ms ease;
+        text-decoration: none;
     }
-    a:after {
-        @apply absolute bg-slate-300 w-full left-0 right-0 bottom-0 h-0.5 origin-bottom-right;
-        content: "";
-        transform: scaleX(0);
-        transition: transform 0.25s ease-out;
-    }
-    a:hover:after {
-        @apply origin-bottom-left;
-        transform: scaleX(1);
+    a:hover {
+        background-size: 100% 0.125rem;
     }
     article > p:not(:last-child), .comment p:not(:last-child), li, blockquote, pre.highlight {
         @apply mb-6;
     }
     article a, aside a, .notice a {
-        @apply text-primary dark:text-blue-400;
-    }
-    article a:after, aside a:after, .notice a:after {
-        @apply bg-primary dark:bg-blue-400;
+        @apply text-primary dark:text-blue-400 bg-gradient-to-r from-primary to-primary dark:from-blue-400 dark:to-blue-400;
     }
     hr {
         @apply w-11/12 mb-6 mx-auto rounded-lg border-t-4 border-slate-200 dark:border-slate-500;
@@ -119,8 +115,8 @@
     @apply p-2 flex rounded-md hover:bg-gray-700;
 }
 
-.mobile-nav-item:after, .header-anchor:after, .logo-anchor:after, .underline-none:after {
-    @apply w-0;
+.mobile-nav-item:hover, .header-anchor:hover, .logo-anchor:hover, .underline-none:hover {
+    background-size: 0% 0rem;
 }
 
 .mobile-nav-item span {

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -77,7 +77,6 @@
     }
     a {
         @apply relative bg-gradient-to-r from-slate-300 to-slate-300;
-        background-image: linear-gradient(#cbd5e1, #cbd5e1);
         background-size: 0% 0.125rem;
         background-repeat: no-repeat;
         background-position: left bottom;


### PR DESCRIPTION
Anchor tags were `inline-block` earlier. This implied that multi-line anchors had only 1 wide underline animation instead of spanning to multi-lines.

For example, when hovered over the author link in [this article](https://genicsblog.com/benny/no-code-ways-to-contribute-to-open-source-projects), the underline is visible as:

<img width="274" alt="image" src="https://user-images.githubusercontent.com/46792249/163690351-38b17900-4104-41df-b8a4-64ab76b23dfd.png">

Which should be spanned across multiple lines instead of 1. This PR fixes the issue. After fix:

<img width="206" alt="image" src="https://user-images.githubusercontent.com/46792249/163690418-d51481be-3b7e-4932-9f62-44490681ef71.png">
