### PR TITLE
Improve series page

### DIFF
--- a/_includes/postbox-horizontal.html
+++ b/_includes/postbox-horizontal.html
@@ -1,0 +1,38 @@
+{% assign author = site.data.authors[post.author] %}
+{% assign category = post.category %}
+<a class="postbox mx-4 md:mx-16 lg:mx-22 my-6 px-6 pb-4 bg-white dark:bg-background rounded-2xl shadow-xl shadow-slate-200 dark:shadow-none border-4 hover:border-{{ category }} dark:hover:border-slate-200 dark:hover:!border-{{ category }} dark:border-slate-600 transition underline-none"
+    href="{{ post.url }}">
+  <div class="flex flex-col lg:flex-row p-2">
+    <div class="flex justify-center items-center lg:w-1/2 md:mb-0">
+      {% if post.image %}
+      <img
+        src="{{ post.image }}"
+        class="w-full md:w-3/4 lg:w-full rounded-xl shadow-xl aspect-video m-8"
+      />
+      {% endif %}
+    </div>
+    <div class="flex flex-col justify-center lg:items-start w-full lg:w-1/2 lg:ml-12">
+      {% if post.title %} 
+      <h1 class="text-4xl font-black tracking-tight">{{ post.title | truncate: 50 }}</h1>
+      {% endif %}
+      
+      {% if post.excerpt %}
+      <span class="mt-0.5 text-justify">{{ post.excerpt }}</span>
+      {% endif %}
+
+      <div class="flex justify-between mt-8 w-full">
+        <div class="flex items-center">
+          <img class="rounded-full w-10 h-10" width="40px" height="40px" src="{{ author.avatar }}" />
+          <span class="ml-4">
+            {{ author.name | split: " " | first }}
+          </span>
+        </div>
+        <div class="flex items-center leading-3">
+          <span>
+            {{ post.date | date:"%b %e, %Y" }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</a>

--- a/_layouts/series.html
+++ b/_layouts/series.html
@@ -30,12 +30,12 @@
     {% assign series = page.path | split:"/" | last | split:"." | first %}
     <main>
         <section class="p-6 sm:p-10">
-            {% assign posts = site.posts | where_exp:"item", "item.series == series" %}
-            {% assign arrSize = posts | size%}
+            {% assign posts = site.posts | where_exp:"item", "item.series == series" | reverse %}
+            {% assign arrSize = posts | size %}
             {% if arrSize > 0 %}
-            <div class="flex flex-col sm:grid sm:grid-cols-2 lg:grid-cols-3 sm:gap-4 md:gap-4 lg:gap-6 text-center">
+            <div class="flex flex-col">
                 {% for post in posts %}
-                {% include postbox.html %}
+                {% include postbox-horizontal.html %}
                 {% endfor %}
             </div>
             {% else %}


### PR DESCRIPTION
Fixes #2

Horizontal postboxes:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46792249/164214722-a7d266e2-6431-42d0-9805-d3aaaa586537.png">

Instead of grid:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/46792249/164214855-6b903edf-9724-4770-94ab-84aac5fd300c.png">

Also, posts are shown in reverse order in series so that the first post in series comes first and the last one comes at the end.