### PR TITLE
Revert to normal selection colors for code-blocks

### DIFF
--- a/assets/css/prism.css
+++ b/assets/css/prism.css
@@ -1,18 +1,6 @@
 /* modified from PrismJS 1.25.0
 https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash+batch+c+cpp+csv+dart+docker+git+groovy+ignore+java+json+kotlin+python+jsx+regex+yaml */
 
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-	text-shadow: none;
-	background: #b3d4fc;
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
-	text-shadow: none;
-	background: #b3d4fc;
-}
-
 @media print {
 	code[class*="language-"],
 	pre[class*="language-"] {


### PR DESCRIPTION
Regarding #28, for now this PR reverts to use default selection colors for code blocks.

<img width="687" alt="image" src="https://user-images.githubusercontent.com/46792249/169030902-b13331c8-2991-4f43-8d7b-6fb6b0796fd6.png">

Still, if there's a better color scheme we might end up using it.