### PR TITLE
Remove redundant pages from sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem "jekyll"
 group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-feed"
-  gem "jekyll-sitemap"
   gem "jekyll-postcss"
   gem "jekyll-minifier"
   gem "jekyll-archives"

--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,6 @@ extlinks:
 # Build settings
 plugins:
   - jekyll-feed
-  - jekyll-sitemap
   - jekyll-postcss
   - jekyll-minifier
   - jekyll-archives

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -20,7 +20,7 @@
 <meta name="twitter:description" content="{{ description }}">
 <meta property="og:description" content="{{ description }}">
 
-{% if page.sitemap == false or page.url == "/404" %}
+{% if page.sitemap == false or page.url contains "/page/" %}
 <meta name="robots" content="noindex">
 {% endif %}
 

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -17,6 +17,10 @@
     <meta property="og:image" content="{{ avatar }}">
     <meta property="og:image:alt" content="{{ author.name }}">
 
+    {% if page.url contains "/page/" %}
+    <meta name="robots" content="noindex">
+    {% endif %}
+
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@genicsblog">
     <meta name="twitter:image" content="{{ avatar }}">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,48 @@
+---
+# adapted from https://github.com/jekyll/jekyll-sitemap/blob/master/lib/sitemap.xml
+---
+<?xml version="1.0" encoding="UTF-8"?>
+{% if page.xsl %}
+  <?xml-stylesheet type="text/xsl" href="{{ "/sitemap.xsl" | absolute_url }}"?>
+{% endif %}
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% assign collections = site.collections | where_exp:'collection','collection.output != false' %}
+  {% for collection in collections %}
+    {% assign docs = collection.docs | where_exp:'doc','doc.sitemap != false' %}
+    {% for doc in docs %}
+      {% if doc.url contains "/page/" %}
+        {% continue %}
+      {% endif %}
+      <url>
+        <loc>{{ doc.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+        {% if doc.last_modified_at or doc.date %}
+          <lastmod>{{ doc.last_modified_at | default: doc.date | date_to_xmlschema }}</lastmod>
+        {% endif %}
+      </url>
+    {% endfor %}
+  {% endfor %}
+
+  {% assign pages = site.html_pages | where_exp:'doc','doc.sitemap != false' | where_exp:'doc','doc.url != "/404.html"' %}
+  {% for page in pages %}
+    {% if page.url contains "/page/" %}
+      {% continue %}
+    {% endif %}
+    <url>
+      <loc>{{ page.url | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+      {% if page.last_modified_at %}
+        <lastmod>{{ page.last_modified_at | date_to_xmlschema }}</lastmod>
+      {% endif %}
+    </url>
+  {% endfor %}
+
+  {% assign static_files = page.static_files | where_exp:'page','page.sitemap != false' | where_exp:'page','page.name != "404.html"' %}
+  {% for file in static_files %}
+    {% if file.url contains "/page/" %}
+      {% continue %}
+    {% endif %}
+    <url>
+      <loc>{{ file.path | replace:'/index.html','/' | absolute_url | xml_escape }}</loc>
+      <lastmod>{{ file.modified_time | date_to_xmlschema }}</lastmod>
+    </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
Secondary pages with `/page/:num` don't add the necessary value to SEO and have low content which isn't good. But on the other hand, they are good for users to explore the site.

This PR removes those pages from sitemap by moving to a manual generation instead of `jekyll-sitemap` plugin.

 Also add `noindex` meta tags to those pages so as to avoid indexing them. Disallow search engines from indexing the staging.genicsblog.com domain by fixing `robots.txt` as well.