### PR TITLE
Add link preview component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :jekyll_plugins do
   gem "jekyll-loading-lazy"
   gem "jekyll-redirect-from"
   gem "jekyll-auto-authors"
+  gem "jekyll-url-metadata"
 end
 
 # Performance-booster for watching directories on Windows

--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,7 @@ plugins:
   - jekyll-loading-lazy
   - jekyll-redirect-from
   - jekyll-auto-authors
+  - jekyll-url-metadata
 
 pagination:
   enabled: true

--- a/_includes/linkpreview.html
+++ b/_includes/linkpreview.html
@@ -1,0 +1,68 @@
+<!-- prettier-ignore -->
+{% assign meta = include.url | metadata %}
+
+{% if meta['og:image'] != blank %}
+  {% assign img_first_char = meta['og:image'] | slice: 0 %}
+
+  {% if img_first_char == '/' %}
+    {% assign image = meta['og:image'] | prepend: include.url %}
+  {% else %}
+    {% assign image = meta['og:image'] %}
+  {% endif %}
+{% elsif meta['twitter:image'] != blank %}
+  {% assign img_first_char = meta['twitter:image'] | slice: 0 %}
+
+  {% if img_first_char == '/' %}
+    {% assign image = meta['twitter:image'] | prepend: include.url %}
+  {% else %}
+    {% assign image = meta['twitter:image'] %}
+  {% endif %}
+{% endif %}
+
+{% if meta['description'] != blank %}
+  {% assign description = meta['description'] %}
+{% elsif meta['og:description'] != blank %}
+  {% assign description = meta['og:description'] %}
+{% endif %}
+
+<div
+  class="mb-6 rounded-2xl border-2 lg:border-4 hover:border-slate-600 dark:hover:border-slate-200 dark:border-slate-600"
+>
+  <a
+    class="underline-none linkpreview"
+    href="{{ include.url }}"
+    target="_blank"
+  >
+    <div
+      class="p-4 lg:p-6{% if image != blank %} flex flex-col md:flex-row{%endif%}"
+    >
+      {% if image != blank %}
+      <img
+        src="{{ image }}"
+        class="w-full md:max-w-[40%] rounded-xl aspect-video lg:m-4"
+      />
+      {% endif %}
+
+      <div
+        class="mt-4 flex flex-col justify-center w-full{% if image != blank %} md:w-1/2 md:ml-4 md:mt-0{% endif %}"
+      >
+        <h3 class="tracking-tight line-clamp-2 lg:text-4xl">
+          <!-- prettier-ignore -->
+          {% if include.title != blank %}
+            {{ include.title }}
+          {% else %}
+            {{ meta['title'] }}
+          {% endif %}
+        </h3>
+
+        {% if description != blank %}
+        <p class="text-sm lg:text-base line-clamp-4">{{ description }}</p>
+        {% endif %}
+
+        <span class="text-gray-500 dark:text-gray-400 text-sm">
+          {{ include.url | hostname }} &gt;
+        </span>
+      </div>
+    </div>
+  </a>
+</div>

--- a/_includes/linkpreview.html
+++ b/_includes/linkpreview.html
@@ -31,6 +31,7 @@
   <a
     class="underline-none linkpreview"
     href="{{ include.url }}"
+    rel="{% if include.rel != blank %}{{ include.rel }}{% else %}nofollow noopener noreferrer{% endif %}"
     target="_blank"
   >
     <div

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -126,7 +126,7 @@
     @apply mb-6;
   }
 
-  article a,
+  article a:not(.linkpreview),
   aside a,
   .notice a,
   .cta-link {


### PR DESCRIPTION
Fixes #3 

This PR adds a new link preview component that can be embedded to posts via:

```liquid
{% include linkpreview.html url = "https://genicsblog.com" title = "Genics Blog: An open source developer publication" %}
```

Where `url` is a mandatory field and `title` is optional.

There's an additional `rel` attribute (optional) that specifies the link type for the preview. By default its value is `nofollow noopener noreferrer`.

Sometimes, websites dynamically change the `<title>` tag on page load, through javascript. In that case, if `title` prop is passed to the include specifically, it is preferred over the extracted `<title>` tag from the website.

Preview (desktop):

<img width="984" alt="image" src="https://user-images.githubusercontent.com/46792249/182022225-0158ca73-d55c-4e78-9d89-bb322dcd2f9f.png">

Preview (mobile):

<img width="239" alt="image" src="https://user-images.githubusercontent.com/46792249/182022260-99979279-0832-435e-9073-50203c5f2684.png">