### PR TITLE
Automatic formatting for age in author bios

### DIFF
--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -5,7 +5,14 @@
     {% assign optimizeAvatar = site.img_src_prefix.avatar %}
   {% endif %}
   {% assign author = page.pagination.author_data %}
-  {% assign description = author.bio %}
+
+  {% if author.birthdate %}
+    {% assign bio = author | format_bio %}
+  {% else %}
+    {% assign bio = author.bio %}
+  {% endif %}
+
+  {% assign description = bio %}
   {% assign avatar = author.avatar %}
   {% assign links = author.links %}
 
@@ -110,7 +117,7 @@
 
         <h4>{{ author.role }}</h4>
 
-        <p class="mt-2">{{ author.bio }}</p>
+        <p class="mt-2">{{ bio }}</p>
 
         <div class="grid grid-flow-col justify-center gap-6 items-center mt-6">
           {% if links.stackoverflow != blank %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -186,7 +186,12 @@ layout: default
           </div>
         </figcaption>
 
-        <p class="leading-5 font-medium text-justify">{{ author.bio }}</p>
+        {% if author.birthdate %}
+          {% assign bio = author | format_bio %}
+        {% else %}
+          {% assign bio = author.bio %}
+        {% endif %}
+        <p class="leading-5 font-medium text-justify">{{ bio }}</p>
       </div>
     </figure>
 

--- a/_plugins/format_bio.rb
+++ b/_plugins/format_bio.rb
@@ -1,0 +1,22 @@
+require 'date'
+require 'liquid'
+
+module Jekyll
+  module FormatBio
+    def format_bio(author)
+      return author['bio'] if author['birthdate'].nil?
+
+      today = Date.today
+      since = Date.parse(author['birthdate'])
+      years = today.year - since.year
+
+      if (today.month < since.month) || (today.month == since.month && today.day < since.day)
+       years -= 1
+      end
+
+      return author['bio'].gsub('{ age }', years.to_s)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::FormatBio)


### PR DESCRIPTION
Certain authors have age in their [bio](https://github.com/genicsblog/genicsblog.com/blob/main/_data/authors.yml) which is hard to track and update. This PR introduces the logic to generate age based on birthdate.

Existing authors will be contacted to choose whether to keep or remove the number from their bios.